### PR TITLE
make the container always keep up status

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    restart: always
     container_name: agent-twitter-client
     environment:
       - TWITTER_USERNAME=${TWITTER_USERNAME}


### PR DESCRIPTION
The parameter of `restart: always` do:
- The container will always restart, regardless of the exit status.
- It will also restart when the Docker daemon restarts.
